### PR TITLE
skip test if MouseX::Foreign is not available

### DIFF
--- a/t/900_mouse_bugs/014_autoload.t
+++ b/t/900_mouse_bugs/014_autoload.t
@@ -4,6 +4,10 @@
 use strict;
 use warnings;
 use Test::More;
+BEGIN {
+    eval "require MouseX::Foreign;";
+    plan skip_all => "MouseX::Foreign is required for this test" if $@;
+}
 
 {
     package Base;


### PR DESCRIPTION
This test was failing if 'MouseX::Foreign' was not installed.
