### PR TITLE
Use workaround for Perl-RT #69939 only if Perl is older than 5.14

### DIFF
--- a/mouse.h
+++ b/mouse.h
@@ -33,9 +33,13 @@ void
 mouse_throw_error(SV* const metaobject, SV* const data /* not used */, const char* const fmt, ...)
     __attribute__format__(__printf__, 3, 4);
 
+#if (PERL_BCDVERSION < 0x5014000)
 /* workaround RT #69939 */
 I32
 mouse_call_sv_safe(pTHX_ SV*, I32);
+#else
+#define mouse_call_sv_safe Perl_call_sv
+#endif
 
 #define call_sv_safe(sv, flags)     mouse_call_sv_safe(aTHX_ sv, flags)
 #define call_method_safe(m, flags)  mouse_call_sv_safe(aTHX_ newSVpvn_flags(m, strlen(m), SVs_TEMP), flags | G_METHOD)

--- a/t/001_mouse/073_errsv.t
+++ b/t/001_mouse/073_errsv.t
@@ -1,6 +1,5 @@
 #!perl
 # https://rt.cpan.org/Ticket/Display.html?id=75313
-# https://rt.cpan.org/Ticket/Display.html?id=77227
 use strict;
 use Test::More tests => 1;
 

--- a/t/001_mouse/074_default_errsv.t
+++ b/t/001_mouse/074_default_errsv.t
@@ -1,0 +1,27 @@
+#!perl
+# https://rt.cpan.org/Ticket/Display.html?id=77227
+use strict;
+
+use Test::More;
+if($] < 5.014) {
+    plan( skip_all => 'Perl 5.14 is required for this test' );
+}
+else {
+    plan( tests => 1 );
+
+    {
+        package Foo;
+        use Mouse;
+        has e => (
+            is => 'ro',
+            default => sub { $@ },
+        );
+    }
+
+    $@ = "foo";
+    my $Foo = Foo->new;
+    is $Foo->e, "foo";
+}
+
+done_testing;
+

--- a/xs-src/MouseUtil.xs
+++ b/xs-src/MouseUtil.xs
@@ -123,6 +123,7 @@ mouse_throw_error(SV* const metaobject, SV* const data /* not used */, const cha
     }
 }
 
+#if (PERL_BCDVERSION < 0x5014000)
 /* workaround Perl-RT #69939 */
 I32
 mouse_call_sv_safe(pTHX_ SV* const sv, I32 const flags) {
@@ -146,6 +147,7 @@ mouse_call_sv_safe(pTHX_ SV* const sv, I32 const flags) {
 
     return count;
 }
+#endif
 
 void
 mouse_must_defined(pTHX_ SV* const value, const char* const name) {


### PR DESCRIPTION
The mouse_call_sv_safe wrapper should be used only for Perl older than 5.14. For newer Perl this wrapper is unnecessary and clears $@ variable used in "default" or "build" attribute modifiers.
