### PR TITLE
Add maybe_type() from Moose::Util::TypeConstraints

### DIFF
--- a/lib/Mouse/Util/TypeConstraints.pm
+++ b/lib/Mouse/Util/TypeConstraints.pm
@@ -12,7 +12,7 @@ Mouse::Exporter->setup_import_methods(
         as where message optimize_as
         from via
 
-        type subtype class_type role_type duck_type
+        type subtype class_type role_type maybe_type duck_type
         enum
         coerce
 
@@ -217,6 +217,11 @@ sub role_type {
         },
         role         => $role,
     );
+}
+
+sub maybe_type {
+    my $param = shift;
+    return _find_or_create_parameterized_type($TYPE{Maybe}, $param);
 }
 
 sub duck_type {


### PR DESCRIPTION
This passes Moose-t-failing/040_type_constraints/021_maybe_type_constraint.t
up to line 107 where check with no args fails.

Fixing check requires messing with XS beyond my ability, and I'm not sure how to integrate a partial passing test.  So I'm going to leave that up to somebody else.
