### PR TITLE
Get perlcritic tests working for PC 1.118.

### DIFF
--- a/lib/Mouse/Exporter.pm
+++ b/lib/Mouse/Exporter.pm
@@ -17,6 +17,8 @@ BEGIN{
 require Mouse::Util;
 
 sub import{
+    ## no critic ProhibitBitwiseOperators
+
     # strict->import;
     $^H              |= $strict_bits;
     # warnings->import('all', FATAL => 'recursion');
@@ -169,10 +171,10 @@ sub do_import {
     }
 
     # strict->import;
-    $^H              |= $strict_bits;
+    $^H              |= $strict_bits;                   ## no critic ProhibitBitwiseOperators
     # warnings->import('all', FATAL => 'recursion');
-    ${^WARNING_BITS} |= $warnings::Bits{all};
-    ${^WARNING_BITS} |= $warnings_extra_bits;
+    ${^WARNING_BITS} |= $warnings::Bits{all};           ## no critic ProhibitBitwiseOperators
+    ${^WARNING_BITS} |= $warnings_extra_bits;           ## no critic ProhibitBitwiseOperators
 
     if($spec->{INIT_META}){
         my $meta;

--- a/xt/006-perlcritic.t
+++ b/xt/006-perlcritic.t
@@ -11,8 +11,7 @@ plan skip_all => "Test::Perl::Critic is not installed." if $@;
 all_critic_ok('lib');
 
 __END__
-
-exclude=ProhibitStringyEval ProhibitExplicitReturnUndef RequireBarewordIncludes
+exclude=ProhibitStringyEval ProhibitExplicitReturnUndef RequireBarewordIncludes ProhibitAccessOfPrivateData 
 
 [TestingAndDebugging::ProhibitNoStrict]
 allow=refs
@@ -22,4 +21,3 @@ equivalent_modules = Mouse Mouse::Exporter Mouse::Util Mouse::Util::TypeConstrai
 
 [TestingAndDebugging::RequireUseWarnings]
 equivalent_modules = Mouse Mouse::Exporter Mouse::Util Mouse::Util::TypeConstraints
-


### PR DESCRIPTION
ProhibitAccessOfPrivateData was introduced and it's just too broad.

ProhibitBitwiseOperators was introduced and it's fine but for a handful
of locations which I've marked with no critic.
