### PR TITLE
Make trigger pass in the old value for Moose compatibility.

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -45,6 +45,7 @@ requires 'Scalar::Util' => 1.14;
 test_requires 'Test::More' => 0.88;
 
 # to keep zero-dependencies
+include 'Test::Fatal';
 include 'Test::Exception::LessClever';
 include 'Test::Requires';
 

--- a/lib/Mouse/Meta/Method/Accessor.pm
+++ b/lib/Mouse/Meta/Method/Accessor.pm
@@ -62,6 +62,7 @@ sub _generate_accessor_any{
         # this setter
         $accessor .= 'return ' if !$is_weak && !$trigger && !$should_deref;
 
+        $accessor .= "my \@old_value = exists $slot ? $slot : ();\n" if $trigger;
         $accessor .= "$slot = $value;\n";
 
         if ($is_weak) {
@@ -69,7 +70,7 @@ sub _generate_accessor_any{
         }
 
         if ($trigger) {
-            $accessor .= '$trigger->('.$self.', '.$value.');' . "\n";
+            $accessor .= '$trigger->('.$self.', '.$value.', @old_value);' . "\n";
         }
 
         $accessor .= "}\n";

--- a/t/001_mouse/016-trigger.t
+++ b/t/001_mouse/016-trigger.t
@@ -14,8 +14,7 @@ do {
         is => 'rw',
         default => 10,
         trigger => sub {
-            my ($self, $value) = @_;
-            push @trigger, [$self, $value];
+            push @trigger, [@_];
         },
     );
 
@@ -60,7 +59,7 @@ is(@trigger, 0, "trigger not called on read");
 
 is($object->attr(50), 50, "setting the value");
 is(@trigger, 1, "trigger was called on read");
-is_deeply([splice @trigger], [[$object, 50]], "correct arguments to trigger in the accessor");
+is_deeply([splice @trigger], [[$object, 50, 10]], "correct arguments to trigger in the accessor");
 
 is($object->foobar,        'piyo');
 lives_ok { $object->foobar('baz') } "triggers that clear the attr";

--- a/t/020_attributes/004_attribute_triggers.t
+++ b/t/020_attributes/004_attribute_triggers.t
@@ -6,7 +6,7 @@ use warnings;
 use Scalar::Util 'isweak';
 
 use Test::More;
-use Test::Exception;
+use Test::Fatal;
 
 
 {
@@ -50,27 +50,27 @@ use Test::Exception;
     my $baz = Baz->new;
     isa_ok($baz, 'Baz');
 
-    lives_ok {
+    is( exception {
         $foo->bar($bar);
-    } '... did not die setting bar';
+    }, undef, '... did not die setting bar' );
 
     is($foo->bar, $bar, '... set the value foo.bar correctly');
     is($bar->foo, $foo, '... which in turn set the value bar.foo correctly');
 
     ok(isweak($bar->{foo}), '... bar.foo is a weak reference');
 
-    lives_ok {
+    is( exception {
         $foo->bar(undef);
-    } '... did not die un-setting bar';
+    }, undef, '... did not die un-setting bar' );
 
     is($foo->bar, undef, '... set the value foo.bar correctly');
     is($bar->foo, $foo, '... which in turn set the value bar.foo correctly');
 
     # test the writer
 
-    lives_ok {
+    is( exception {
         $foo->set_baz($baz);
-    } '... did not die setting baz';
+    }, undef, '... did not die setting baz' );
 
     is($foo->get_baz, $baz, '... set the value foo.baz correctly');
     is($baz->foo, $foo, '... which in turn set the value baz.foo correctly');
@@ -105,13 +105,13 @@ use Test::Exception;
     package Bling;
     use Mouse;
 
-    ::dies_ok {
+    ::isnt( ::exception {
         has('bling' => (is => 'rw', trigger => 'Fail'));
-    } '... a trigger must be a CODE ref';
+    }, undef, '... a trigger must be a CODE ref' );
 
-    ::dies_ok {
+    ::isnt( ::exception {
         has('bling' => (is => 'rw', trigger => []));
-    } '... a trigger must be a CODE ref';
+    }, undef, '... a trigger must be a CODE ref' );
 }
 
 # Triggers do not fire on built values
@@ -140,7 +140,7 @@ use Test::Exception;
 
 {
     my $blarg;
-    lives_ok { $blarg = Blarg->new; } 'Blarg->new() lives';
+    is( exception { $blarg = Blarg->new; }, undef, 'Blarg->new() lives' );
     ok($blarg, 'Have a $blarg');
     foreach my $attr (qw/foo bar baz/) {
         is($blarg->$attr(), "default $attr value", "$attr has default value");
@@ -152,7 +152,7 @@ use Test::Exception;
     is_deeply(\%Blarg::trigger_calls, { map { $_ => 1 } qw/foo bar baz/ }, 'All triggers fired once on assign');
     is_deeply(\%Blarg::trigger_vals, { map { $_ => "Different $_ value" } qw/foo bar baz/ }, 'All triggers given assigned values');
 
-    lives_ok { $blarg => Blarg->new( map { $_ => "Yet another $_ value" } qw/foo bar baz/ ) } '->new() with parameters';
+    is( exception { $blarg => Blarg->new( map { $_ => "Yet another $_ value" } qw/foo bar baz/ ) }, undef, '->new() with parameters' );
     is_deeply(\%Blarg::trigger_calls, { map { $_ => 2 } qw/foo bar baz/ }, 'All triggers fired once on construct');
     is_deeply(\%Blarg::trigger_vals, { map { $_ => "Yet another $_ value" } qw/foo bar baz/ }, 'All triggers given assigned values');
 }
@@ -182,30 +182,15 @@ use Test::Exception;
 
     $attr->set_value( $foo, 3 );
 
-    note 'skip Moose specific features';
-    last;
-
     is_deeply(
         \@Foo::calls,
         [ [ $foo, 3, 2 ] ],
         'trigger called correctly on second set via meta-API',
     );
     @Foo::calls = ();
-
-    $attr->set_raw_value( $foo, 4 );
-
-    is_deeply(
-        \@Foo::calls,
-        [ ],
-        'trigger not called using set_raw_value method',
-    );
-    @Foo::calls = ();
 }
 
 {
-    note 'skip Moose specific features';
-    last;
-
     my $foo = Foo->new(foo => 2);
     is_deeply(
         \@Foo::calls,


### PR DESCRIPTION
Moose docs say...

```
       trigger => $code
           The trigger option is a CODE reference which will be called
           after the value of the attribute is set. The CODE ref is passed
           the instance itself, the updated value, and the original value
           if the attribute was already set.
```

The XS code could probably be written better without the has_old_value sentinel,
but I don't know how.

I pulled in t/attributes/attribute_triggers.t from the latest Moose as it has
compatible trigger tests.  They switched from Test::Exception to Test::Fatal
so I've added Test::Fatal as an include.

For rt.cpan.org 76880
