### PR TITLE
Fixed XS_VERSION error while building on Perl 5.8.8

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,4 @@ Moose-t/
 !LICENSE
 /lib/Mouse.xs
 /MANIFEST
+/xs-src/xs_version.h

--- a/builder/MyBuilder.pm
+++ b/builder/MyBuilder.pm
@@ -28,12 +28,18 @@ sub new {
 }
 
 sub ACTION_code {
-    my ($class) = @_;
+    my ($self) = @_;
 
     system($^X, 'tool/generate-mouse-tiny.pl', 'lib/Mouse/Tiny.pm') == 0
         or warn "Cannot generate Mouse::Tiny: $!";
 
-    unless ($class->pureperl_only) {
+    open my $fh, '>', 'xs-src/xs_version.h';
+    print {$fh} "#ifndef XS_VERSION\n";
+    printf {$fh} "#define XS_VERSION \"%s\"\n", $self->dist_version;
+    print {$fh} "#endif\n";
+    close($fh);
+
+    unless ($self->pureperl_only) {
         require ExtUtils::ParseXS;
         for my $xs (qw(
             xs-src/MouseAccessor.xs
@@ -50,7 +56,7 @@ sub ACTION_code {
         }
     }
 
-    $class->SUPER::ACTION_code();
+    $self->SUPER::ACTION_code();
 }
 
 sub ACTION_test {

--- a/xs-src/MouseTypeConstraints.xs
+++ b/xs-src/MouseTypeConstraints.xs
@@ -5,6 +5,7 @@
  */
 
 #include "mouse.h"
+#include "xs_version.h"
 
 #ifndef SvRXOK
 #define SvRXOK(sv) (SvROK(sv) && SvMAGICAL(SvRV(sv)) && mg_find(SvRV(sv), PERL_MAGIC_qr))

--- a/xs-src/MouseUtil.xs
+++ b/xs-src/MouseUtil.xs
@@ -1,4 +1,5 @@
 #include "mouse.h"
+#include "xs_version.h"
 
 #define MY_CXT_KEY "Mouse::Util::_guts" XS_VERSION
 typedef struct {


### PR DESCRIPTION
XS_VERSION is required by MY_CXT_KEY.

https://github.com/gfx/p5-Mouse/issues/18
ref. http://blog.64p.org/entry/2014/02/26/140302
