### PR TITLE
Update minimum perl version

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -1,4 +1,4 @@
-requires 'perl', '5.8.1';
+requires 'perl', '5.008005';
 
 # Scalar::Util < 1.14 has a bug.
 # > Fixed looks_like_number(undef) to return false for perl >= 5.009002


### PR DESCRIPTION
Because Module::Build::XSUtil requires Perl 5.8.5 or higher.

Related #15
