### PR TITLE
Correct required Perl versions(#25)

### DIFF
--- a/builder/MyBuilder.pm
+++ b/builder/MyBuilder.pm
@@ -2,7 +2,7 @@ package builder::MyBuilder;
 use strict;
 use warnings;
 use utf8;
-use 5.008_001;
+use 5.008_005;
 use base qw(Module::Build::XSUtil);
 
 sub new {

--- a/lib/Mouse.pm
+++ b/lib/Mouse.pm
@@ -1,5 +1,5 @@
 package Mouse;
-use 5.006_002;
+use 5.008_005;
 
 use Mouse::Exporter; # enables strict and warnings
 
@@ -401,10 +401,6 @@ keywords (such as L</extends>) it will break loudly instead breaking subtly.
 We have a public git repository L<https://github.com/gfx/p5-Mouse>:.
 
     git clone git://github.com/gfx/p5-Mouse.git
-
-=head1 DEPENDENCIES
-
-Perl 5.6.2 or later.
 
 =head1 SEE ALSO
 


### PR DESCRIPTION
Module::Build::XSUtil requires Perl 5.8.5 or higher.
And remove DEPENDENCIES section, this section is no point now.

Cc: #25 
