### PR TITLE
Skip t/900_mouse_bugs/018_issue41.t before perl 5.10

### DIFF
--- a/t/900_mouse_bugs/018_issue41.t
+++ b/t/900_mouse_bugs/018_issue41.t
@@ -2,6 +2,12 @@
 
 use Test::More;
 
+BEGIN {
+    plan skip_all
+           => 'perl 5.10 required to test Mouse/strict.pm/use 5.10 interaction'
+             unless "$]" >= 5.010
+}
+
 # without explicit 'strict'
 {
     package Foo;


### PR DESCRIPTION
Hello,

 t/900_mouse_bugs/018_issue41.t is failing on perl 5.8 because of the literal "use 5.010" in the test. This commit just skip the test for these old perls.

Vincent