### PR TITLE
Fix thread issue for Perl 5.22 or higher

### DIFF
--- a/mouse.h
+++ b/mouse.h
@@ -106,6 +106,14 @@ SV* mouse_av_at_safe(pTHX_ AV* const mi, I32 const ix);
 #define MOUSE_mg_slot(mg)   MOUSE_mg_obj(mg)
 #define MOUSE_mg_xa(mg)    ((AV*)MOUSE_mg_ptr(mg))
 
+static inline MAGIC *MOUSE_get_magic(CV *cv, MGVTBL *vtbl)
+{
+#ifndef MULTIPLICITY
+    return (MAGIC*)(CvXSUBANY(cv).any_ptr);
+#else
+    return mg_findext((SV*)cv, PERL_MAGIC_ext, vtbl);
+#endif
+}
 
 /* mouse_instance.xs stuff */
 SV*  mouse_instance_create     (pTHX_ HV* const stash);

--- a/t/900_mouse_bugs/017_issue29.t
+++ b/t/900_mouse_bugs/017_issue29.t
@@ -3,10 +3,13 @@
 package main;
 use strict;
 use warnings;
-use Test::More skip_all => 'See https://github.com/gfx/p5-Mouse/issues/29';
+use constant HAS_THREADS => eval{ require threads && require threads::shared };
+use Test::More;
 
-use Test::Requires qw(threads); # XXX: ithreads is discuraged!
-
+use if !HAS_THREADS, 'Test::More',
+    (skip_all => "This is a test for threads ($@)");
+use if $Test::More::VERSION >= 2.00, 'Test::More',
+    (skip_all => "Test::Builder2 has bugs about threads");
 
 {
     package Foo;

--- a/xs-src/MouseAccessor.xs
+++ b/xs-src/MouseAccessor.xs
@@ -122,7 +122,9 @@ mouse_accessor_generate(pTHX_ SV* const attr, XSUBADDR_t const accessor_impl){
      * although we use MAGIC for gc, we also store mg to
      * CvXSUBANY for efficiency (gfx)
      */
+#ifndef MULTIPLICITY
     CvXSUBANY(xsub).any_ptr = (void*)mg;
+#endif
 
     return xsub;
 }
@@ -262,7 +264,7 @@ XS(XS_Mouse_accessor)
 {
     dVAR; dXSARGS;
     dMOUSE_self;
-    MAGIC* const mg = (MAGIC*)XSANY.any_ptr;
+    MAGIC* const mg = MOUSE_get_magic(cv, &mouse_accessor_vtbl);
 
     SP -= items; /* PPCODE */
     PUTBACK;
@@ -285,7 +287,7 @@ XS(XS_Mouse_reader)
 {
     dVAR; dXSARGS;
     dMOUSE_self;
-    MAGIC* const mg = (MAGIC*)XSANY.any_ptr;
+    MAGIC* const mg = MOUSE_get_magic(cv, &mouse_accessor_vtbl);
 
     if (items != 1) {
         mouse_throw_error(MOUSE_mg_attribute(mg), NULL,
@@ -303,7 +305,7 @@ XS(XS_Mouse_writer)
 {
     dVAR; dXSARGS;
     dMOUSE_self;
-    MAGIC* const mg = (MAGIC*)XSANY.any_ptr;
+    MAGIC* const mg = MOUSE_get_magic(cv, &mouse_accessor_vtbl);
 
     if (items != 2) {
         mouse_throw_error(MOUSE_mg_attribute(mg), NULL,
@@ -351,7 +353,9 @@ mouse_simple_accessor_generate(pTHX_
      * although we use MAGIC for gc, we also store mg to CvXSUBANY
      * for efficiency (gfx)
      */
+#ifndef MULTIPLICITY
     CvXSUBANY(xsub).any_ptr = (void*)mg;
+#endif
 
     return xsub;
 }
@@ -360,7 +364,7 @@ XS(XS_Mouse_simple_reader)
 {
     dVAR; dXSARGS;
     dMOUSE_self;
-    MAGIC* const mg = (MAGIC*)XSANY.any_ptr;
+    MAGIC* const mg = MOUSE_get_magic(cv, &mouse_accessor_vtbl);
     SV* value;
 
     if (items != 1) {
@@ -389,7 +393,7 @@ XS(XS_Mouse_simple_writer)
 {
     dVAR; dXSARGS;
     dMOUSE_self;
-    SV* const slot = MOUSE_mg_slot((MAGIC*)XSANY.any_ptr);
+    SV* const slot = MOUSE_mg_slot(MOUSE_get_magic(cv, &mouse_accessor_vtbl));
 
     if (items != 2) {
         croak("Expected exactly two argument for a writer of %"SVf,
@@ -404,7 +408,7 @@ XS(XS_Mouse_simple_clearer)
 {
     dVAR; dXSARGS;
     dMOUSE_self;
-    SV* const slot = MOUSE_mg_slot((MAGIC*)XSANY.any_ptr);
+    SV* const slot = MOUSE_mg_slot(MOUSE_get_magic(cv, &mouse_accessor_vtbl));
     SV* value;
 
     if (items != 1) {
@@ -421,7 +425,7 @@ XS(XS_Mouse_simple_predicate)
 {
     dVAR; dXSARGS;
     dMOUSE_self;
-    SV* const slot = MOUSE_mg_slot((MAGIC*)XSANY.any_ptr);
+    SV* const slot = MOUSE_mg_slot(MOUSE_get_magic(cv, &mouse_accessor_vtbl));
 
     if (items != 1) {
         croak("Expected exactly one argument for a predicate of %"SVf, slot);
@@ -435,7 +439,7 @@ XS(XS_Mouse_simple_predicate)
 XS(XS_Mouse_inheritable_class_accessor) {
     dVAR; dXSARGS;
     dMOUSE_self;
-    SV* const slot = MOUSE_mg_slot((MAGIC*)XSANY.any_ptr);
+    SV* const slot = MOUSE_mg_slot(MOUSE_get_magic(cv, &mouse_accessor_vtbl));
     SV* value;
     HV* stash;
 


### PR DESCRIPTION
Please review this change. I don't understand XS well. 

I confirmed that test of #29 and tests of `Text::Xslates` are passed with this change.
I fixed by reference to [Class::Accessor::Inherited::XS](https://github.com/vovkasm/Class-Accessor-Inherited-XS).

This is related to #29, #49.