### PR TITLE
Register Mouse classes in %INC

### DIFF
--- a/lib/Mouse.pm
+++ b/lib/Mouse.pm
@@ -131,6 +131,9 @@ sub init_meta {
     my $metaclass  = $args{metaclass}  || 'Mouse::Meta::Class';
 
     my $meta = $metaclass->initialize($class);
+    my $filename = Mouse::Util::module_notional_filename($meta->name);
+    $INC{$filename} = '(set by Mouse)'
+        unless exists $INC{$filename};
 
     $meta->add_method(meta => sub{
         return $metaclass->initialize(ref($_[0]) || $_[0]);

--- a/lib/Mouse/Role.pm
+++ b/lib/Mouse/Role.pm
@@ -115,6 +115,9 @@ sub init_meta{
     my $metaclass  = $args{metaclass}  || 'Mouse::Meta::Role';
 
     my $meta = $metaclass->initialize($class);
+    my $filename = Mouse::Util::module_notional_filename($meta->name);
+    $INC{$filename} = '(set by Mouse)'
+        unless exists $INC{$filename};
 
     $meta->add_method(meta => sub{
         $metaclass->initialize(ref($_[0]) || $_[0]);

--- a/lib/Mouse/Util.pm
+++ b/lib/Mouse/Util.pm
@@ -232,6 +232,15 @@ sub does_role {
     }
 }
 
+# Taken from Module::Runtime
+sub module_notional_filename {
+    my $class = shift;
+
+    $class =~ s{::}{/}g;
+
+    return $class.'.pm';
+}
+
 # Utilities from Class::MOP
 
 sub get_code_info;
@@ -278,12 +287,11 @@ sub _try_load_one_class {
 
     return '' if is_class_loaded($class);
 
-    $class  =~ s{::}{/}g;
-    $class .= '.pm';
+    my $filename = module_notional_filename($class);
 
     return do {
         local $@;
-        eval { require $class };
+        eval { require $filename };
         $@;
     };
 }


### PR DESCRIPTION
Currently, there is no easy way to create Mouse classes in "oneliners":
$ perl -e '{ package Foo; use Mouse; } use Foo'
Can't locate Foo.pm in @INC

This patch contains Moose-like solving of this issue.
