### PR TITLE
Specify context argument

### DIFF
--- a/mouse.h
+++ b/mouse.h
@@ -106,7 +106,7 @@ SV* mouse_av_at_safe(pTHX_ AV* const mi, I32 const ix);
 #define MOUSE_mg_slot(mg)   MOUSE_mg_obj(mg)
 #define MOUSE_mg_xa(mg)    ((AV*)MOUSE_mg_ptr(mg))
 
-static inline MAGIC *MOUSE_get_magic(CV *cv, MGVTBL *vtbl)
+static inline MAGIC *MOUSE_get_magic(pTHX_ CV *cv, MGVTBL *vtbl)
 {
 #ifndef MULTIPLICITY
     return (MAGIC*)(CvXSUBANY(cv).any_ptr);

--- a/xs-src/MouseAccessor.xs
+++ b/xs-src/MouseAccessor.xs
@@ -264,7 +264,7 @@ XS(XS_Mouse_accessor)
 {
     dVAR; dXSARGS;
     dMOUSE_self;
-    MAGIC* const mg = MOUSE_get_magic(cv, &mouse_accessor_vtbl);
+    MAGIC* const mg = MOUSE_get_magic(aTHX_ cv, &mouse_accessor_vtbl);
 
     SP -= items; /* PPCODE */
     PUTBACK;
@@ -287,7 +287,7 @@ XS(XS_Mouse_reader)
 {
     dVAR; dXSARGS;
     dMOUSE_self;
-    MAGIC* const mg = MOUSE_get_magic(cv, &mouse_accessor_vtbl);
+    MAGIC* const mg = MOUSE_get_magic(aTHX_ cv, &mouse_accessor_vtbl);
 
     if (items != 1) {
         mouse_throw_error(MOUSE_mg_attribute(mg), NULL,
@@ -305,7 +305,7 @@ XS(XS_Mouse_writer)
 {
     dVAR; dXSARGS;
     dMOUSE_self;
-    MAGIC* const mg = MOUSE_get_magic(cv, &mouse_accessor_vtbl);
+    MAGIC* const mg = MOUSE_get_magic(aTHX_ cv, &mouse_accessor_vtbl);
 
     if (items != 2) {
         mouse_throw_error(MOUSE_mg_attribute(mg), NULL,
@@ -364,7 +364,7 @@ XS(XS_Mouse_simple_reader)
 {
     dVAR; dXSARGS;
     dMOUSE_self;
-    MAGIC* const mg = MOUSE_get_magic(cv, &mouse_accessor_vtbl);
+    MAGIC* const mg = MOUSE_get_magic(aTHX_ cv, &mouse_accessor_vtbl);
     SV* value;
 
     if (items != 1) {
@@ -393,7 +393,7 @@ XS(XS_Mouse_simple_writer)
 {
     dVAR; dXSARGS;
     dMOUSE_self;
-    SV* const slot = MOUSE_mg_slot(MOUSE_get_magic(cv, &mouse_accessor_vtbl));
+    SV* const slot = MOUSE_mg_slot(MOUSE_get_magic(aTHX_ cv, &mouse_accessor_vtbl));
 
     if (items != 2) {
         croak("Expected exactly two argument for a writer of %"SVf,
@@ -408,7 +408,7 @@ XS(XS_Mouse_simple_clearer)
 {
     dVAR; dXSARGS;
     dMOUSE_self;
-    SV* const slot = MOUSE_mg_slot(MOUSE_get_magic(cv, &mouse_accessor_vtbl));
+    SV* const slot = MOUSE_mg_slot(MOUSE_get_magic(aTHX_ cv, &mouse_accessor_vtbl));
     SV* value;
 
     if (items != 1) {
@@ -425,7 +425,7 @@ XS(XS_Mouse_simple_predicate)
 {
     dVAR; dXSARGS;
     dMOUSE_self;
-    SV* const slot = MOUSE_mg_slot(MOUSE_get_magic(cv, &mouse_accessor_vtbl));
+    SV* const slot = MOUSE_mg_slot(MOUSE_get_magic(aTHX_ cv, &mouse_accessor_vtbl));
 
     if (items != 1) {
         croak("Expected exactly one argument for a predicate of %"SVf, slot);
@@ -439,7 +439,7 @@ XS(XS_Mouse_simple_predicate)
 XS(XS_Mouse_inheritable_class_accessor) {
     dVAR; dXSARGS;
     dMOUSE_self;
-    SV* const slot = MOUSE_mg_slot(MOUSE_get_magic(cv, &mouse_accessor_vtbl));
+    SV* const slot = MOUSE_mg_slot(MOUSE_get_magic(aTHX_ cv, &mouse_accessor_vtbl));
     SV* value;
     HV* stash;
 

--- a/xs-src/MouseTypeConstraints.xs
+++ b/xs-src/MouseTypeConstraints.xs
@@ -35,7 +35,7 @@ mouse_tc_check(pTHX_ SV* const tc_code, SV* const sv) {
     assert(SvTYPE(cv) == SVt_PVCV);
 
     if(CvXSUB(cv) == XS_Mouse_constraint_check){ /* built-in type constraints */
-        MAGIC* const mg = MOUSE_get_magic(cv, &mouse_util_type_constraints_vtbl);
+        MAGIC* const mg = MOUSE_get_magic(aTHX_ cv, &mouse_util_type_constraints_vtbl);
 #ifndef MULTIPLICITY
         assert(CvXSUBANY(cv).any_ptr != NULL);
 #endif
@@ -574,7 +574,7 @@ static
 XSPROTO(XS_Mouse_constraint_check) {
     dVAR;
     dXSARGS;
-    MAGIC* const mg = MOUSE_get_magic(cv, &mouse_util_type_constraints_vtbl);
+    MAGIC* const mg = MOUSE_get_magic(aTHX_ cv, &mouse_util_type_constraints_vtbl);
     SV* sv;
 
     if(items < 1){


### PR DESCRIPTION
This is necessary for building with older Perl.
I got following error when building with older Perls(< 5.22.0) which enables `-Dusethreads`.

```
% ./Build
Building Mouse
Generate Mouse::Tiny ...
done.
xs-src/MouseAccessor.xs => xs-src/MouseAccessor.c
xs-src/MouseAttribute.xs => xs-src/MouseAttribute.c
xs-src/MouseTypeConstraints.xs => xs-src/MouseTypeConstraints.c
xs-src/MouseUtil.xs => xs-src/MouseUtil.c
cc -I. -Ixs-src -I/home/syohei/.plenv/versions/5.20.2/lib/perl5/5.20.2/x86_64-linux-thread-multi/CORE -fPIC -Wall -Wextra -Wdeclaration-after-statement -Wc++-compat -c -D_REENTRANT -D_GNU_SOURCE -fwrapv -fno-strict-aliasing -pipe -fstack-protector -I/usr/local/include -D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64 -O2 -g -o xs-src/MouseTypeConstraints.o xs-src/MouseTypeConstraints.c
In file included from ./xshelper.h:36:0,
                 from ./mouse.h:6,
                 from xs-src/MouseTypeConstraints.xs:7:
./mouse.h: In function ‘MOUSE_get_magic’:
/home/syohei/.plenv/versions/5.20.2/lib/perl5/5.20.2/x86_64-linux-thread-multi/CORE/perl.h:155:16: error: ‘my_perl’ undeclared (first use in this function)
 #  define aTHX my_perl
                ^
/home/syohei/.plenv/versions/5.20.2/lib/perl5/5.20.2/x86_64-linux-thread-multi/CORE/perl.h:168:18: note: in expansion of macro ‘aTHX’
 #  define aTHX_  aTHX,
                  ^
/home/syohei/.plenv/versions/5.20.2/lib/perl5/5.20.2/x86_64-linux-thread-multi/CORE/embed.h:318:43: note: in expansion of macro ‘aTHX_’
 #define mg_findext(a,b,c) Perl_mg_findext(aTHX_ a,b,c)
                                           ^
./mouse.h:114:12: note: in expansion of macro ‘mg_findext’
     return mg_findext((SV*)cv, PERL_MAGIC_ext, vtbl);
            ^
/home/syohei/.plenv/versions/5.20.2/lib/perl5/5.20.2/x86_64-linux-thread-multi/CORE/perl.h:155:16: note: each undeclared identifier is reported only once for each function it appears in
 #  define aTHX my_perl
                ^
/home/syohei/.plenv/versions/5.20.2/lib/perl5/5.20.2/x86_64-linux-thread-multi/CORE/perl.h:168:18: note: in expansion of macro ‘aTHX’
 #  define aTHX_  aTHX,
                  ^
/home/syohei/.plenv/versions/5.20.2/lib/perl5/5.20.2/x86_64-linux-thread-multi/CORE/embed.h:318:43: note: in expansion of macro ‘aTHX_’
 #define mg_findext(a,b,c) Perl_mg_findext(aTHX_ a,b,c)
                                           ^
./mouse.h:114:12: note: in expansion of macro ‘mg_findext’
     return mg_findext((SV*)cv, PERL_MAGIC_ext, vtbl);
```