### PR TITLE
various minor fixes

### DIFF
--- a/Build.PL
+++ b/Build.PL
@@ -8,6 +8,7 @@ use 5.008_001;
 use strict;
 use warnings;
 use utf8;
+use lib '.';
 
 BEGIN { push @INC, '.' }
 use builder::MyBuilder;

--- a/lib/Mouse/Util.pm
+++ b/lib/Mouse/Util.pm
@@ -62,6 +62,7 @@ BEGIN{
         (my $hack_mouse_file = __FILE__) =~ s/.Util//; # .../Mouse/Util.pm -> .../Mouse.pm
         $xs = eval sprintf("#line %d %s\n", __LINE__, $hack_mouse_file) . q{
             local $^W = 0; # workaround 'redefine' warning to &install_subroutines
+            no warnings 'redefine';
             require XSLoader;
             XSLoader::load('Mouse', $VERSION);
             Mouse::Util->import({ into => 'Mouse::Meta::Method::Constructor::XS' }, ':meta');

--- a/mouse.h
+++ b/mouse.h
@@ -120,6 +120,7 @@ SV* mouse_av_at_safe(pTHX_ AV* const mi, I32 const ix);
 PERL_STATIC_INLINE MAGIC *MOUSE_get_magic(pTHX_ CV *cv, MGVTBL *vtbl)
 {
 #ifndef MULTIPLICITY
+    PERL_UNUSED_ARG(vtbl);
     return (MAGIC*)(CvXSUBANY(cv).any_ptr);
 #else
     return mg_findext((SV*)cv, PERL_MAGIC_ext, vtbl);
@@ -145,7 +146,7 @@ void mouse_instance_weaken_slot(pTHX_ SV* const instance, SV* const slot);
 #define get_slots(self, key)        get_slot(self, sv_2mortal(newSVpvs_share(key)))
 #define set_slots(self, key, value) set_slot(self, sv_2mortal(newSVpvs_share(key)), value)
 
-/* mouse_simle_accessor.xs for meta object protocols */
+/* mouse_simple_accessor.xs for meta object protocols */
 #define INSTALL_SIMPLE_READER(klass, name) \
     INSTALL_SIMPLE_READER_WITH_KEY(klass, name, name)
 #define INSTALL_SIMPLE_READER_WITH_KEY(klass, name, key) \

--- a/tool/generate-mouse-tiny.pl
+++ b/tool/generate-mouse-tiny.pl
@@ -3,6 +3,7 @@ use strict;
 use warnings;
 use File::Find;
 use Fatal qw(open close);
+use lib ('.', 'lib');
 #use File::Slurp 'slurp';
 #use List::MoreUtils 'uniq';
 #use autodie;
@@ -19,7 +20,7 @@ sub uniq{
     return grep{ !$seen{$_}++ } @_;
 }
 
-require './lib/Mouse/Spec.pm';
+require Mouse::Spec;
 
 my $MouseTinyFile = shift || 'lib/Mouse/Tiny.pm';
 

--- a/xs-src/MouseAccessor.xs
+++ b/xs-src/MouseAccessor.xs
@@ -254,7 +254,7 @@ mouse_attr_set(pTHX_ SV* const self, MAGIC* const mg, SV* value){
         call_sv_safe(trigger, G_VOID | G_DISCARD);
         /* need not SPAGAIN */
 
-        assert(SvTYPE(value) != SVTYPEMASK);
+        /* wrong assert(SvFLAGS(value) > SVTYPEMASK); can be undef/SVt_NULL */
     }
 
     mouse_push_value(aTHX_ value, flags);

--- a/xs-src/MouseTypeConstraints.xs
+++ b/xs-src/MouseTypeConstraints.xs
@@ -1,6 +1,6 @@
 /*
  * TypeConstraint stuff
- *  - Mouse::Util::TypeConstraints (including OptimizedConstraionts)
+ *  - Mouse::Util::TypeConstraints (including OptimizedConstraints)
  *  - Mouse::Meta::TypeConstraint
  */
 
@@ -506,7 +506,7 @@ mouse_tc_generate(pTHX_ const char* const name, check_fptr_t const fptr, SV* con
     CV* xsub;
     MAGIC* mg;
 
-    xsub = newXS(name, XS_Mouse_constraint_check, __FILE__);
+    xsub = newXS((const char*)name, XS_Mouse_constraint_check, __FILE__);
     mg = sv_magicext(
         (SV*)xsub,
         param,       /* mg_obj: refcnt will be increased */


### PR DESCRIPTION
- fixes for (c)perls without . in @INC (security)
  pushes . to @INC where needed
- silence PERL_UNUSED_ARG warning
- silence type coercion warning `const char* const name` => `const char* name`
- fix wrong assert: was always true, but failed in `t/020_attributes/004_attribute_triggers.t`
  test 8 with value = undef.
- one typo

tested from 5.8.9 up to cperl 5.22.2. cperl still has the XS redefined warning, because I rewrote XSLoader in XS, need to check why the trick doesn't work there. Maybe just use DynaLoader.
