### PR TITLE
Fix attribute override problem with recent perl (issue #64)

### DIFF
--- a/lib/Mouse/Meta/Class.pm
+++ b/lib/Mouse/Meta/Class.pm
@@ -222,8 +222,17 @@ sub add_attribute {
             or $self->throw_error('You must provide a name for the attribute');
 
         if ($name =~ s/^\+//) { # inherited attributes
-            my $inherited_attr = $self->find_attribute_by_name($name)
-                or $self->throw_error("Could not find an attribute by the name of '$name' to inherit from in ".$self->name);
+            # do not use find_attribute_by_name to avoid problems with cached attributes list
+            # because we're about to change it anyway
+            my $inherited_attr;
+            foreach my $i ( @{ $self->_calculate_all_attributes } ) {
+                if ( $i->name eq $name ) {
+                    $inherited_attr = $i;
+                    last;
+                }
+            }
+            $self->throw_error("Could not find an attribute by the name of '$name' to inherit from in ".$self->name)
+                unless $inherited_attr;
 
             $attr = $inherited_attr->clone_and_inherit_options(%args);
         }

--- a/t/900_mouse_bugs/019_issue64.t
+++ b/t/900_mouse_bugs/019_issue64.t
@@ -1,0 +1,16 @@
+#!/usr/bin/perl
+use strict;
+use warnings;
+
+use Test::More;
+use File::Basename;
+use File::Spec;
+
+use lib File::Spec->catdir( dirname($0), basename($0, '.t') );
+
+BEGIN {
+    use_ok('Holder');
+}
+
+done_testing();
+

--- a/t/900_mouse_bugs/019_issue64/Bar.pm
+++ b/t/900_mouse_bugs/019_issue64/Bar.pm
@@ -1,0 +1,12 @@
+package Bar;
+use Mouse;
+
+foreach my $i ( 0 .. 23 ) {
+    has "attr_$i" => (
+        is  => 'ro',
+        isa => 'Str',
+    );
+}
+
+1;
+

--- a/t/900_mouse_bugs/019_issue64/Foo.pm
+++ b/t/900_mouse_bugs/019_issue64/Foo.pm
@@ -1,0 +1,9 @@
+package Foo;
+use Mouse;
+extends 'Bar';
+
+has '+attr_0'  => (
+    isa => 'Num',
+);
+
+1;

--- a/t/900_mouse_bugs/019_issue64/Holder.pm
+++ b/t/900_mouse_bugs/019_issue64/Holder.pm
@@ -1,0 +1,3 @@
+package Holder;
+use Foo;
+1;


### PR DESCRIPTION
Using mouse metaclass attribute cache inside add_attribute may
cause strange problems such as missing attributes or memory
corruption.