### PR TITLE
Adding single quotes around Object, ArrayRef and HashRef barewords

### DIFF
--- a/t/020_attributes/014_misc_attribute_coerce_lazy.t
+++ b/t/020_attributes/014_misc_attribute_coerce_lazy.t
@@ -25,13 +25,13 @@ use Test::Exception;
     use Mouse::Util::TypeConstraints;
 
     subtype Header =>
-        => as Object
+        => as 'Object'
         => where { $_->isa('HTTPHeader') };
 
     coerce Header
-        => from ArrayRef
+        => from 'ArrayRef'
             => via { HTTPHeader->new(array => $_[0]) }
-        => from HashRef
+        => from 'HashRef'
             => via { HTTPHeader->new(hash => $_[0]) };
 
     has 'headers'  => (

--- a/t/040_type_constraints/005_util_type_coercion.t
+++ b/t/040_type_constraints/005_util_type_coercion.t
@@ -22,13 +22,13 @@ BEGIN {
 }
 
 subtype Header =>
-    => as Object
+    => as 'Object'
     => where { $_->isa('HTTPHeader') };
 
 coerce Header
-    => from ArrayRef
+    => from 'ArrayRef'
         => via { HTTPHeader->new(array => $_[0]) }
-    => from HashRef
+    => from 'HashRef'
         => via { HTTPHeader->new(hash => $_[0]) };
 
 


### PR DESCRIPTION
Hi there,

I've discovered that two tests have been failing which can be solved by adding single quotes to barewords. The failed tests are:

```
t/020_attributes/014_misc_attribute_coerce_lazy.t .............. Bareword found where operator expected at t/020_attributes/014_misc_attribute_coerce_lazy.t line 31, near "coerce"
        (Missing semicolon on previous line?)
Bareword found where operator expected at t/020_attributes/014_misc_attribute_coerce_lazy.t line 37, near "has"
        (Missing semicolon on previous line?)
String found where operator expected at t/020_attributes/014_misc_attribute_coerce_lazy.t line 37, near "has 'headers'"
        (Do you need to predeclare has?)
"my" variable $r masks earlier declaration in same statement at t/020_attributes/014_misc_attribute_coerce_lazy.t line 47.
syntax error at t/020_attributes/014_misc_attribute_coerce_lazy.t line 31, near "coerce "
Execution of t/020_attributes/014_misc_attribute_coerce_lazy.t aborted due to compilation errors.
t/020_attributes/014_misc_attribute_coerce_lazy.t .............. Dubious, test returned 255 (wstat 65280, 0xff00)
No subtests run 
```

```
t/040_type_constraints/005_util_type_coercion.t ................ 1/8 Semicolon seems to be missing at t/040_type_constraints/005_util_type_coercion.t line 27.
syntax error at t/040_type_constraints/005_util_type_coercion.t line 28, near "coerce "
Execution of t/040_type_constraints/005_util_type_coercion.t aborted due to compilation errors.
# Looks like your test exited with 255 just after 1.
t/040_type_constraints/005_util_type_coercion.t ................ Dubious, test returned 255 (wstat 65280, 0xff00)
Failed 7/8 subtests 
```
With the summary as follows:

```
Test Summary Report
-------------------
t/020_attributes/014_misc_attribute_coerce_lazy.t            (Wstat: 65280 Tests: 0 Failed: 0)
  Non-zero exit status: 255
  Parse errors: No plan found in TAP output
t/040_type_constraints/005_util_type_coercion.t              (Wstat: 65280 Tests: 1 Failed: 0)
  Non-zero exit status: 255
  Parse errors: Bad plan.  You planned 8 tests but ran 1.
t/040_type_constraints/018_custom_parameterized_types.t      (Wstat: 0 Tests: 28 Failed: 0)
  TODO passed:   13, 19-20, 22
Files=301, Tests=6105, 53 wallclock secs ( 1.45 usr  0.54 sys + 21.48 cusr  5.17 csys = 28.64 CPU)
Result: FAIL
```

After fixing the barewords in my pull request, all tests pass:

```
Test Summary Report
-------------------
t/040_type_constraints/018_custom_parameterized_types.t      (Wstat: 0 Tests: 28 Failed: 0)
  TODO passed:   13, 19-20, 22
t/040_type_constraints/021_maybe_type_constraint.t           (Wstat: 0 Tests: 36 Failed: 0)
  TODO passed:   27
Files=301, Tests=6114, 46 wallclock secs ( 1.71 usr  0.41 sys + 24.36 cusr  5.30 csys = 31.78 CPU)
Result: PASS
```

Thanks,
Chris