### PR TITLE
Fix stack collapse on new object BUILD

### DIFF
--- a/t/900_mouse_bugs/020_stack_collapse_on_build.t
+++ b/t/900_mouse_bugs/020_stack_collapse_on_build.t
@@ -1,0 +1,37 @@
+#!/usr/bin/perl
+use strict;
+use warnings;
+
+use Test::More;
+
+{
+    package My::Parent;
+    use Mouse;
+    sub BUILD {}
+}
+{
+    package My::ChildA;
+    use Mouse;
+    extends 'My::Parent';
+    sub BUILD {}
+}
+{
+    package My::ChildB;
+    use Mouse;
+    extends 'My::ChildA';
+    sub BUILD {}
+}
+
+sub fac {
+    my $num = $_[0];
+    if ($num == 1) {
+        My::ChildB->new();
+        return 1;
+    } else {
+        $num * fac($num - 1);
+    }
+}
+
+is fac(2), 2;
+
+done_testing();

--- a/xs-src/Mouse.xs
+++ b/xs-src/Mouse.xs
@@ -394,12 +394,7 @@ mouse_buildall(pTHX_ AV* const xc, SV* const object, SV* const args) {
         PUSHs(args);
         PUTBACK;
 
-        call_sv_safe(AvARRAY(buildall)[i], G_VOID);
-
-        /* discard a scalar which G_VOID returns */
-        SPAGAIN;
-        (void)POPs;
-        PUTBACK;
+        call_sv_safe(AvARRAY(buildall)[i], G_VOID | G_DISCARD);
     }
 }
 
@@ -799,12 +794,7 @@ CODE:
             PUSHs(in_global_destruction);
             PUTBACK;
 
-            call_sv(AvARRAY(demolishall)[i], G_VOID | G_EVAL);
-
-            /* discard a scalar which G_VOID returns */
-            SPAGAIN;
-            (void)POPs;
-            PUTBACK;
+            call_sv(AvARRAY(demolishall)[i], G_VOID | G_EVAL | G_DISCARD);
 
             if(sv_true(ERRSV)){
                 SV* const e = sv_mortalcopy(ERRSV);


### PR DESCRIPTION
Current implementation of calling BUILD from XS discards scalar
by its own POPs. However, it can unexpectedly decrement
PL_stack_sp and lead to stack collapse, especially 'STACK
UNDERFLOW!!!'.
Fix discards on BUILD and also DEMOLISH using G_DISCARD flag
according to the perldoc documentation.
- http://perldoc.perl.org/perlcall.html

## Stack Snapshot

* `-Ds` output of perl-5.24.1 `t/900_mouse_bugs/020_stack_collapse_on_build.t` 
* with this fix
```
... snip ....
    =>  *  IV(2)  PV("My::ChildB")  *  \HV()  PV("strict_constructor")  
    =>  *  IV(2)  PV("My::ChildB")  *  \HV()  CV(strict_constructor)  
    =>  *  IV(2)  PV("My::ChildB")  \HV()  \HV()  
    =>  *  IV(2)  PV("My::ChildB")  
    =>  *  IV(2)  PV("My::ChildB")  \HV()  \HV()  
    =>  *  IV(2)  PV("My::ChildB")  
    =>  *  IV(2)  PV("My::ChildB")  \HV()  \HV()  
    =>  *  IV(2)  PV("My::ChildB")  
    =>  *  IV(2)  \HV()  
    =>  *  IV(2)  
    =>  *  IV(2)  *  
    =>  *  IV(2)  *  IV(1)  
    =>  *  IV(2)  IV(1)  
    =>  *  IV(2)  
    =>  *  IV(2)  
    =>  *  IV(2)  
    =>  *  IV(2)  IV(2)  
    =>  *  IV(2)  IV(2)  GV()  
    =>  IV(2)  IV(2)  
    =>  
... snip ...
```
* without this fix
```
    =>  *  IV(2)  PV("My::ChildB")  *  \HV()  PV("strict_constructor")  
    =>  *  IV(2)  PV("My::ChildB")  *  \HV()  CV(strict_constructor)  
    =>  *  IV(2)  PV("My::ChildB")  \HV()  \HV()  
    =>  *  IV(2)  PV("My::ChildB")  
    =>  *  IV(2)  \HV()  \HV()  
    =>  *  IV(2)  
    =>  *  \HV()  \HV()  
    =>  *  
    =>  *  \HV()  \HV()  
    =>  *  (FREED)  
    =>  *  (FREED)  *  
    =>  *  (FREED)  *  IV(1)  
    =>  *  (FREED)  IV(1)  
Use of uninitialized value in multiplication (*) at /path/to/p5-Mouse/t/900_mouse_bugs/020_stack_collapse_on_build.t line 31.
    =>  *  NV(0)  
    =>  *  NV(0)  
    =>  *  NV(0)  
    =>  *  NV(0)  IV(2)  
    =>  *  NV(0)  IV(2)  GV()  
    =>  NV(0)  IV(2)  
    =>  
```
