### PR TITLE
Sort output from find

### DIFF
--- a/tool/generate-mouse-tiny.pl
+++ b/tool/generate-mouse-tiny.pl
@@ -40,6 +40,7 @@ find({
     },
     no_chdir => 1,
 }, 'lib');
+@files = sort @files;
 
 my $mouse_tiny = '';
 
@@ -49,7 +50,7 @@ for my $file (uniq
         'lib/Mouse/Util.pm',
         'lib/Mouse/Meta/TypeConstraint.pm',
         'lib/Mouse/Util/TypeConstraints.pm',
-            sort @files) {
+            @files) {
 
     my $contents = slurp $file;
 


### PR DESCRIPTION
because we want reproducible output
even though filesystem order is undeterministic

See https://reproducible-builds.org/ for why this is good.

Without the patch, @files was used in 2 places but only sorted in 1


Was filed earlier at https://rt.cpan.org/Public/Bug/Display.html?id=122336