### PR TITLE
use PERL_UNUSED_RESULT

### DIFF
--- a/xs-src/MouseTypeConstraints.xs
+++ b/xs-src/MouseTypeConstraints.xs
@@ -149,7 +149,7 @@ S_nv_is_integer(pTHX_ NV const nv) {
     else {
         char buf[64];  /* Must fit sprintf/Gconvert of longest NV */
         const char* p;
-        (void)Gconvert(nv, NV_DIG, 0, buf);
+        PERL_UNUSED_RESULT(Gconvert(nv, NV_DIG, 0, buf));
         p = &buf[0];
 
         /* -?[0-9]+ */


### PR DESCRIPTION
This PR fixes the following warning:
```
./Build
...
cc -I. -Ixs-src -I/home/skaji/env/plenv/versions/relocatable-5.26.1.1/lib/5.26.1/x86_64-linux/CORE -fPIC -Wall -Wextra -Wdeclaration-after-statement -Wc++-compat -c -fwrapv -fno-strict-aliasing -pipe -fstack-protector -I/usr/local/include -D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64 -D_FORTIFY_SOURCE=2 -O2 -g -o xs-src/MouseTypeConstraints.o xs-src/MouseTypeConstraints.c
xs-src/MouseTypeConstraints.xs: In function ‘S_nv_is_integer’:
xs-src/MouseTypeConstraints.xs:152:9: warning: ignoring return value of ‘gcvt’, declared with attribute warn_unused_result [-Wunused-result]
         (void)Gconvert(nv, NV_DIG, 0, buf);
         ^
```