### PR TITLE
Possible threading fix.

### DIFF
--- a/t/001_mouse/060-threads.t
+++ b/t/001_mouse/060-threads.t
@@ -1,7 +1,5 @@
 #!perl
 
-use Test::More skip_all => "FIXME";
-
 use strict;
 use warnings;
 use constant HAS_THREADS => eval{ require threads && require threads::shared };


### PR DESCRIPTION
Hi @skaji 
This change makes tests related to threads pass.
Not sure why hv_fetch succeeds where hv_fetch_ent fails but it's happening only in threading tests.
Without the fix
```
ksv@ubuntu:~/p5-Mouse$ perl -e 'use threads; package b { use Mouse; } print threads->create(sub { return b->new })->join, "\n"'
Thread 1 terminated abnormally: No package name defined for metaclass at -e line 1.
```
With the fix:
```
perl -e 'use threads; package b { use Mouse; } print threads->create(sub { return b->new })->join, "\n"'
b=HASH(0x55f6dd4c5a50)
```
I'd like to take time and investigate further, but it smells like a bug in perl itself.