### PR TITLE
Fix for threads and XS

### DIFF
--- a/t/001_mouse/060-threads.t
+++ b/t/001_mouse/060-threads.t
@@ -1,7 +1,5 @@
 #!perl
 
-use Test::More skip_all => "FIXME";
-
 use strict;
 use warnings;
 use constant HAS_THREADS => eval{ require threads && require threads::shared };

--- a/xs-src/Mouse.xs
+++ b/xs-src/Mouse.xs
@@ -456,14 +456,14 @@ PROTOTYPES: DISABLE
 
 BOOT:
 {
-    mouse_package   = newSVpvs_share("package");
-    mouse_namespace = newSVpvs_share("namespace");
-    mouse_methods   = newSVpvs_share("methods");
-    mouse_name      = newSVpvs_share("name");
-    mouse_coerce    = newSVpvs_share("coerce");
+    mouse_package   = newSVpvs("package");
+    mouse_namespace = newSVpvs("namespace");
+    mouse_methods   = newSVpvs("methods");
+    mouse_name      = newSVpvs("name");
+    mouse_coerce    = newSVpvs("coerce");
 
-    mouse_get_attribute      = newSVpvs_share("get_attribute");
-    mouse_get_attribute_list = newSVpvs_share("get_attribute_list");
+    mouse_get_attribute      = newSVpvs("get_attribute");
+    mouse_get_attribute_list = newSVpvs("get_attribute_list");
 
     CALL_BOOT(Mouse__Util);
     CALL_BOOT(Mouse__Util__TypeConstraints);


### PR DESCRIPTION
@skaji @gfx 
Looks like threading and scalars made by *_share do not mix well.
This deprecates my earlier PR https://github.com/gfx/p5-Mouse/pull/91 because it's much cleaner fix.
I use Mouse extensively in my module https://metacpan.org/pod/AI::MXNet and all tests passed while using Mouse with change.