### PR TITLE
do not emit redefine warnings if they are attributes

### DIFF
--- a/lib/Mouse/Meta/Attribute.pm
+++ b/lib/Mouse/Meta/Attribute.pm
@@ -260,7 +260,9 @@ sub install_accessors{
                 no strict 'refs';
                 !defined &{ $metaclass->name . '::' . $name };
             };
-            if ( $metaclass->name->can($name) && !$is_stub ) {
+            if (    $metaclass->name->can($name)
+                && !$metaclass->find_attribute_by_name($name)
+                && !$is_stub ) {
                 my $t = $metaclass->has_method($name) ? 'method' : 'function';
                 Carp::cluck("You are overwriting a locally defined $t"
                     . " ($name) with an accessor");

--- a/t/020_attributes/011_more_attr_delegation.t
+++ b/t/020_attributes/011_more_attr_delegation.t
@@ -106,13 +106,17 @@ do not fail at compile time.
         );
     } "all_methods requires explicit isa";
 
+
     ::lives_ok {
+        my @warn;
+        local $SIG{__WARN__} = sub { push @warn, @_ };
         has child_a => (
             isa     => "ChildA",
             is      => "ro",
             default => sub { ChildA->new },
             handles => qr/.*/,
         );
+        ::note $_ for @warn;
     } "allow all_methods with explicit isa";
 
     ::lives_ok {
@@ -143,6 +147,8 @@ do not fail at compile time.
     } "can't create attr with generative handles parameter and no isa";
 
     ::lives_ok {
+        my @warn;
+        local $SIG{__WARN__} = sub { push @warn, @_ };
         has child_d => (
             isa     => "ChildD",
             is      => "ro",
@@ -152,6 +158,7 @@ do not fail at compile time.
                 return;
             }
         );
+        ::note $_ for @warn;
     } "can't create attr with generative handles parameter and no isa";
 
     ::lives_ok {

--- a/t/901_todo/attribute_warn.t
+++ b/t/901_todo/attribute_warn.t
@@ -1,0 +1,29 @@
+use strict;
+use warnings;
+use Test::More;
+
+plan skip_all => 'todo';
+
+# See
+#  t/020_attributes/011_more_attr_delegation.t
+#  https://github.com/gfx/p5-Mouse/issues/86
+#  https://github.com/gfx/p5-Mouse/pull/90
+{
+    package A;
+    use Mouse;
+
+    # if "handles" is a Regexp, "isa" is required. So this block dies
+    eval { has attr => (is => "ro", handles => qr/./) };
+
+    # but "attr" is registered somehow, so this emits
+    # "You are overwriting a locally defined method (attr) with an accessor"
+    # I think this implies Mouse may leak something...
+    my @warn;
+    {
+        local $SIG{__WARN__} = sub { push @warn, @_ };
+        has attr => (is => 'ro');
+    }
+    ::is @warn, 0;
+}
+
+done_testing;


### PR DESCRIPTION
Follow up #90 