### PR TITLE
fix undefined PERL_UNUSED_RESULT symbol on old perl/Devel::PPPort

### DIFF
--- a/xs-src/mouse.h
+++ b/xs-src/mouse.h
@@ -38,6 +38,14 @@ AV* mouse_mro_get_linear_isa(pTHX_ HV* const stash);
 #endif
 #endif
 
+#ifndef PERL_UNUSED_RESULT
+#if defined(__GNUC__) && defined(HASATTRIBUTE_WARN_UNUSED_RESULT)
+#define PERL_UNUSED_RESULT(v) STMT_START { __typeof__(v) z = (v); (void)sizeof(z); } STMT_END
+#else
+#define PERL_UNUSED_RESULT(v) ((void)(v))
+#endif
+#endif
+
 extern SV* mouse_package;
 extern SV* mouse_methods;
 extern SV* mouse_name;


### PR DESCRIPTION
Hi.

I'm using perl 5.16 with Mouse on old perl (v5.16.3).

When I try to build latest Mouse, I encountered this error messages.

```
... undefined symbol: PERL_UNUSED_RESULT ...
```

So I added conditional macro for this symbol and then It working now gracefully.